### PR TITLE
Fix handling of local $refs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = jschon-sort
-version = 0.0.2
+version = 0.0.3
 description = Sorts a JSON or YAML document to match a JSON Schema's order of properties
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_jschon_sort.py
+++ b/tests/test_jschon_sort.py
@@ -94,3 +94,42 @@ def test_sort_doc_by_schema__local_ref() -> None:
     # Assert
     assert actual is not doc
     assert json.dumps(actual) == '{"foo": {"start": 10, "end": 20}}'
+
+
+def test_sort_doc_by_schema__oneof() -> None:
+    # Arrange
+    doc_str = '{"abc": {"end": 20, "start": 10}, "xyz": {"to": 40, "from": 30}}'
+    doc = json.loads(doc_str)
+
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "additionalProperties": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "properties": {
+                        "start": {"type": "number"},
+                        "end": {"type": "number"},
+                    },
+                    "required": ["start", "end"],
+                    "additionalProperties": False,
+                },
+                {
+                    "properties": {
+                        "from": {"type": "number"},
+                        "to": {"type": "number"},
+                    },
+                    "required": ["from", "to"],
+                    "additionalProperties": False,
+                },
+            ],
+        },
+    }
+
+    # Act
+    actual = sort_doc_by_schema(doc_data=doc, schema_data=schema)
+
+    # Assert
+    assert actual is not doc
+    assert json.dumps(actual) == '{"abc": {"start": 10, "end": 20}, "xyz": {"from": 30, "to": 40}}'

--- a/tests/test_jschon_sort.py
+++ b/tests/test_jschon_sort.py
@@ -62,3 +62,35 @@ def test_sort_doc_by_schema(schema_version: str) -> None:
     assert actual is not doc
     assert json.dumps(doc) == doc_str, "ensure doc is not modified in place"
     assert json.dumps(actual) == '{"ranges": [{"BBB": 42, "AAA": 42, "start": 10, "end": 20}]}'
+
+
+def test_sort_doc_by_schema__local_ref() -> None:
+    # Arrange
+    doc_str = '{"foo": {"end": 20, "start": 10}}'
+    doc = json.loads(doc_str)
+
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "$defs": {
+            "range": {
+                "type": "object",
+                "properties": {
+                    "start": {"type": "number"},
+                    "end": {"type": "number"},
+                },
+                "required": ["start", "end"],
+                "additionalProperties": False,
+            },
+        },
+        "additionalProperties": {
+            "$ref": "#/$defs/range",
+        },
+    }
+
+    # Act
+    actual = sort_doc_by_schema(doc_data=doc, schema_data=schema)
+
+    # Assert
+    assert actual is not doc
+    assert json.dumps(actual) == '{"foo": {"start": 10, "end": 20}}'


### PR DESCRIPTION
- To streamline sorting code, creating sort keys for all of the schema's nodes, not just object values
- Set JSON node's sort key only if not already set: for referenced schemas, this makes sure we assign the sort key according to the location in referring schema (the property containing the $ref), not the referred schema.
- Rewrite traversal from "iterate over children and do work then recurse" to "do work then iterate over children and recurse"
